### PR TITLE
Add Repository method to run query without reloading

### DIFF
--- a/src/Storage/Query/Handler/PagingHandler.php
+++ b/src/Storage/Query/Handler/PagingHandler.php
@@ -29,7 +29,7 @@ class PagingHandler
             }
 
             $repo = $contentQuery->getEntityManager()->getRepository($contenttype);
-            $query->setQueryBuilder($repo->createQueryBuilder($contenttype));
+            $query->setQueryBuilder($repo->createQueryBuilder('_' . $contenttype));
             $query->setContentType($contenttype);
             $query->setParameters($contentQuery->getParameters());
 
@@ -66,9 +66,9 @@ class PagingHandler
                 ->setMaxResults(null)
                 ->select('COUNT(*) as total');
 
-            $totalItems = count($repo->findWith($query2));
+            $totalItems = count($query2->execute()->fetchAll());
 
-            $result = $repo->findWith($qb);
+            $result = $repo->queryWithLoaded($qb);
             if ($result) {
                 $set->add($result, $contenttype);
                 $set->setTotalResults((int) $totalItems);

--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -33,4 +33,21 @@ class Repository extends ContentRepository
         return $query;
     }
 
+    /**
+     *  This method is used to run the query without loading the mappings again
+     *
+     * @param QueryBuilder $query
+     *
+     * @return array
+     */
+    public function queryWithLoaded(QueryBuilder $query)
+    {
+        $result = $query->execute()->fetchAll();
+        if ($result) {
+            return $this->hydrateAll($result, $query);
+        }
+
+        return [];
+    }
+
 }


### PR DESCRIPTION
Fixes the exceptions with the storage engine.

Root cause was that the repo method `getQueryBuilderAfterMappings` performed a load on the query and then passing it to the `findWith()` method does the same load again.

This is fixed by adding a specific method to the custom repository to run without reloading.